### PR TITLE
Missing Eqivalent instance for Predicate morphisms

### DIFF
--- a/src/Felix/All.agda
+++ b/src/Felix/All.agda
@@ -21,3 +21,4 @@ import Felix.Construct.Arrow
 
 import Felix.Instances.Function
 import Felix.Instances.Identity
+import Felix.Instances.Pred

--- a/src/Felix/Homomorphism.agda
+++ b/src/Felix/Homomorphism.agda
@@ -171,7 +171,7 @@ id-StrongProductsH =
 record CartesianH
   {obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄ (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁)
   {obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄ (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂)
-  {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
+  {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
   ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
   ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
   ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄

--- a/src/Felix/Instances/Pred.agda
+++ b/src/Felix/Instances/Pred.agda
@@ -1,19 +1,18 @@
 {-# OPTIONS --safe --without-K #-}
-open import Level using (Level; suc; _⊔_)
+open import Level using (Level; suc; lift; _⊔_)
 
 module Felix.Instances.Pred (m ℓm : Level) where
 
-open import Data.Product using (_,_; ∃; proj₁)
-open import Relation.Unary using (Pred; _⟨×⟩_; _⟨→⟩_)
+open import Data.Product using (_,_; ∃; Σ; proj₁)
+open import Relation.Unary using (Pred; _≐_; _⟨×⟩_; _⟨→⟩_)
+open import Relation.Unary.Polymorphic using (U)
+open import Relation.Binary.PropositionalEquality as ≡ using (_≡_; _≗_)
 
+open import Felix.Equiv
 open import Felix.Object
 open import Felix.Raw
 private module F {ℓ} where open import Felix.Instances.Function ℓ public
 open F
-
--- Level-generalized U from Relation.Unary
-U : ∀ {a ℓ} {A : Set a} → Pred A ℓ
-U x = ⊤
 
 record PRED : Set (suc (m ⊔ ℓm)) where
   constructor mkᵒ
@@ -32,6 +31,16 @@ record _⇒_ (𝒜 ℬ : PRED) : Set (m ⊔ ℓm) where
   field
     {f}  : ty 𝒜 → ty ℬ
     imp  : (pred 𝒜 ⟨→⟩ pred ℬ) f
+
+equivalent : Equivalent _ _⇒_
+equivalent = record
+  { _≈_ = λ { g h → f g ≗ f h }
+  ; equiv = record
+      { refl  = λ _ → ≡.refl
+      ; sym   = λ f∼g x → ≡.sym (f∼g x)
+      ; trans = λ f∼g g∼h x → ≡.trans (f∼g x) (g∼h x)
+      }
+  } where open _⇒_
 
 module PRED-morphisms where instance
 
@@ -57,8 +66,12 @@ module PRED-functor where instance
   H : Homomorphism _⇒_ _⇾_
   H = record { Fₘ = _⇒_.f }
   
-  catH : CategoryH _⇒_ _⇾_
-  catH = record { F-id = refl ; F-∘ = refl }
+  catH : CategoryH _⇒_ ⦃ eq₁ = equivalent ⦄ _⇾_
+  catH = record
+    { F-cong = λ f∼g → f∼g
+    ; F-id = refl
+    ; F-∘ = refl
+    }
 
   pH : ProductsH PRED _⇾_
   pH = record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id }
@@ -69,6 +82,6 @@ module PRED-functor where instance
   spH = record { ε⁻¹∘ε = L.identityˡ ; ε∘ε⁻¹ = L.identityˡ
                ; μ⁻¹∘μ = L.identityˡ ; μ∘μ⁻¹ = L.identityˡ }
 
-  cartH : CartesianH _⇒_ _⇾_
+  cartH : CartesianH _⇒_ _⇾_ ⦃ eq₁ = equivalent ⦄
   cartH = record { F-! = refl ; F-▵ = refl ; F-exl = refl ; F-exr = refl }
 


### PR DESCRIPTION
Note that before reading Timely Computation I had no idea what PRED is about, now I have only high level overview of what it should do but I have no idea if what I am doing is right. However here is my reasoning:

since objects in the predicate category are Pred, morphisms between the same objects will be constrained in the same way, they can only differ in the function that is constrained.  Therefore those will be equivalent only if that underlying function is equivalent.

Furthermore this instance can't be find in other instaces in this module.  I have no idea why, so I added some hints there.  This workaround suggests that I did something wrong, but I don't know what it is exactly.

Interestingly didn't you run into this error (Missing Equivalent instance) while working on Timely Computation?