### PR TITLE
github actions ci

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+use flake
+
+# source an additional user-specific .envrc in ./.envrc-local
+if [ -e .envrc-local ]; then
+   source .envrc-local
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: "Build"
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v24
+    - run:  nix build -L --show-trace

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 MAlonzo/
 _build/
 
+# build artifacts
+.envrc-local
+.direnv/
+result*
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "agda-stdlib-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684170868,
+        "narHash": "sha256-xTTnCIAGYjjU74m0H/nObIvHwjcbTDTCNt6U944ela4=",
+        "owner": "agda",
+        "repo": "agda-stdlib",
+        "rev": "7c5f3ff90fa7ff1b9d4a522050291119f209a85b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "7c5f3ff",
+        "repo": "agda-stdlib",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agda-stdlib-src": "agda-stdlib-src",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Category theory for denotational design";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=23.05";
+    utils.url = "github:numtide/flake-utils";
+    agda-stdlib-src = {
+      url = "github:agda/agda-stdlib?ref=7c5f3ff";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, utils, agda-stdlib-src }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        standard-library = pkgs.agdaPackages.standard-library.overrideAttrs (final: prev: {
+          version = "2.0";
+          src = agda-stdlib-src;
+        });
+        agdaWithStandardLibrary = pkgs.agda.withPackages (_: [ standard-library ]);
+
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            agdaWithStandardLibrary
+            pkgs.graphviz
+          ];
+        };
+
+        packages.default = pkgs.agdaPackages.mkDerivation {
+          pname = "felix";
+          version = "0.0.1";
+          src = ./.;
+
+          buildInputs = [ standard-library ];
+
+          everythingFile = "./src/Felix/All.agda";
+
+          meta = with pkgs.lib; {
+            description = "Category theory for denotational design";
+            homepage = "https://github.com/conal/felix";
+            # no license file, all rights reserved?
+            # license = licenses.mit;
+            # platforms = platforms.unix;
+            # maintainers = with maintainers; [ ];
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
This is simplest possible things to do, make agda typecheck `Felix.All`.

Few notes however:
- This uses some random standard library version, that was at the top I the time I've locked it. Now that there is a proper 2.0 release it would be nice to use that, however there are some changes to be done and I didn't want them to go into this pr. Should be easy though,
- I've deliberately chosen nixpkgs version that provide agda 2.6.3, because 2.6.4 introduced some changes to instance resolution algorithm and now it cannot determine which of the `IsEquivalent` instance to use in lot of records in the `Felix.Laws`. I don't know yet how to deal with it. But should go into separate pr anyway.

There are few improvements that can be made:
- Generate all/everything file dynamically, as if something isn't imported there it won't be checked,
- add caching, via [cachix](https://www.cachix.org/) so that, we don't have to build standard library on every run, and others could get download development environment as well. (This step requires might require setting an account there)