### PR TITLE
Standard library v2.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "agda-stdlib-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1684170868,
-        "narHash": "sha256-xTTnCIAGYjjU74m0H/nObIvHwjcbTDTCNt6U944ela4=",
+        "lastModified": 1702291622,
+        "narHash": "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=",
         "owner": "agda",
         "repo": "agda-stdlib",
-        "rev": "7c5f3ff90fa7ff1b9d4a522050291119f209a85b",
+        "rev": "2b8fff10f4033b91a6df4007e4a65cb10047c89c",
         "type": "github"
       },
       "original": {
         "owner": "agda",
-        "ref": "7c5f3ff",
+        "ref": "v2.0",
         "repo": "agda-stdlib",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs?ref=23.05";
     utils.url = "github:numtide/flake-utils";
     agda-stdlib-src = {
-      url = "github:agda/agda-stdlib?ref=7c5f3ff";
+      url = "github:agda/agda-stdlib?ref=v2.0";
       flake = false;
     };
   };

--- a/src/Felix/Construct/Product.agda
+++ b/src/Felix/Construct/Product.agda
@@ -87,8 +87,7 @@ module product-instances where instance
     ; ∘≈        = λ (eq₁ , eq₂) (eq₁′ , eq₂′) → ∘≈ eq₁ eq₁′ , ∘≈ eq₂ eq₂′
     }
 
-  open import Function.Equivalence using (Equivalence; equivalence)
-  open import Function.Equality as F using (Π; _⟨$⟩_)
+  open import Function using (Equivalence; mk⇔)
 
   l-cartesian : ∀ {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
                 ⦃ _ :   Products  obj₁ ⦄ ⦃ _ :   Products  obj₂ ⦄
@@ -103,10 +102,10 @@ module product-instances where instance
             e₂ = ∀× {f = f₂} {g₂} {k₂}
             module Q₁ = Equivalence e₁
             module Q₂ = Equivalence e₂
-            h₁ = Q₁.to ⟨$⟩_ ; h₁⁻¹ = Q₁.from ⟨$⟩_
-            h₂ = Q₂.to ⟨$⟩_ ; h₂⁻¹ = Q₂.from ⟨$⟩_
+            h₁ = Q₁.to ; h₁⁻¹ = Q₁.from
+            h₂ = Q₂.to ; h₂⁻¹ = Q₂.from
         in
-        equivalence
+        mk⇔
           (λ (z₁ , z₂) → let eq₁ , eq₁′ = h₁ z₁ ; eq₂ , eq₂′ = h₂ z₂ in
             (eq₁ , eq₂) , (eq₁′ , eq₂′)
             )

--- a/src/Felix/Instances/Function/Laws.agda
+++ b/src/Felix/Instances/Function/Laws.agda
@@ -4,7 +4,7 @@ open import Level
 
 module Felix.Instances.Function.Laws (ℓ : Level) where
 
-open import Function.Equivalence hiding (id; _∘_)
+open import Function using (mk⇔)
 open import Data.Product using (_,_)
 
 open import Felix.Raw hiding (Category; Cartesian; CartesianClosed)
@@ -34,7 +34,7 @@ module →-laws-instances where
     cartesian : Cartesian _⇾_
     cartesian = record
       { ∀⊤ = λ _ → refl≡
-      ; ∀× = equivalence
+      ; ∀× = mk⇔
           (λ k≈f▵g → (λ x → cong exl (k≈f▵g x)) , (λ x → cong exr (k≈f▵g x)))
           (λ (exl∘k≈f , exr∘k≈g) x → cong₂ _,_ (exl∘k≈f x) (exr∘k≈g x))
       ; ▵≈ = λ h≈k f≈g x → cong₂ _,_ (h≈k x) (f≈g x)
@@ -44,7 +44,7 @@ module →-laws-instances where
 
       cartesianClosed : CartesianClosed _⇾_
       cartesianClosed = record
-        { ∀⇛ = equivalence
+        { ∀⇛ = mk⇔
             (λ g≈f (x , y) → sym≡ (cong (λ h → h y) (g≈f x)))
             (λ f≈uncurry-g x → extensionality λ y → sym≡ (f≈uncurry-g (x , y)))
         ; curry≈ = λ f≈g x → extensionality λ y → f≈g (x , y)

--- a/src/Felix/Laws.agda
+++ b/src/Felix/Laws.agda
@@ -4,8 +4,7 @@ module Felix.Laws where
 
 open import Level
 open import Relation.Binary.PropositionalEquality using (_≡_)
-open import Function.Equivalence using (_⇔_; module Equivalence)
-open import Function.Equality using (_⟨$⟩_)
+open import Function using (_⇔_; module Equivalence)
 
 open import Felix.Raw as R hiding (Category; Cartesian; CartesianClosed)
 open import Felix.Equiv
@@ -69,11 +68,11 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
 
   ∀×→ : {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
      → k ≈ f ▵ g → (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g)
-  ∀×→ = to ∀× ⟨$⟩_
+  ∀×→ = to ∀×
 
   ∀×← : {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
      → (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g) → k ≈ f ▵ g
-  ∀×← = from ∀× ⟨$⟩_
+  ∀×← = from ∀×
 
   ▵≈ˡ : {f : a ⇨ c} {h k : a ⇨ d} → h ≈ k → h ▵ f ≈ k ▵ f
   ▵≈ˡ h≈k = ▵≈ h≈k refl
@@ -289,11 +288,11 @@ record CartesianClosed {obj : Set o} ⦃ _ : Products obj ⦄
 
   ∀⇛→ : {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)}
       → g ≈ curry f → f ≈ uncurry g
-  ∀⇛→ = to ∀⇛ ⟨$⟩_
+  ∀⇛→ = to ∀⇛
 
   ∀⇛← : {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)}
       → f ≈ uncurry g → g ≈ curry f
-  ∀⇛← = from ∀⇛ ⟨$⟩_
+  ∀⇛← = from ∀⇛
 
   curry-apply : {a b : obj} → id { a = a ⇛ b } ≈ curry apply
   curry-apply = ∀⇛← (begin

--- a/src/Felix/MakeLawful.agda
+++ b/src/Felix/MakeLawful.agda
@@ -15,7 +15,7 @@ module Felix.MakeLawful
          ⦃ H : Homomorphism _⇨₁_ _⇨₂_ ⦄
  where
 
-open import Function.Equivalence using (equivalence)
+open import Function using (mk⇔)
 
 open import Felix.Raw
 open import Felix.Laws as L hiding (Category; Cartesian; CartesianClosed)
@@ -103,7 +103,7 @@ LawfulCartesianᶠ = record
       ≈˘⟨ F-! ⟩
         Fₘ !
       ∎
-  ; ∀× = λ {a b c} {f g k} → equivalence
+  ; ∀× = λ {a b c} {f g k} → mk⇔
       (λ k≈f▵g → (begin
           Fₘ (exl ∘ k)
         ≈⟨ F-∘ ; ∘≈ʳ k≈f▵g ⟩


### PR DESCRIPTION
Recently there was a proper release of the standard library. This makes sure it is used in the nix/ci, as well some minor changes required to make it work.