### PR TITLE
Agda 2.6.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,16 +19,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685566663,
-        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "lastModified": 1701282334,
+        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "23.05",
+        "ref": "23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -60,11 +60,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Category theory for denotational design";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=23.11";
     utils.url = "github:numtide/flake-utils";
     agda-stdlib-src = {
       url = "github:agda/agda-stdlib?ref=v2.0";

--- a/readme.md
+++ b/readme.md
@@ -9,9 +9,9 @@ This library replaces the overgrown [denotational-hardware](https://github.com/c
 ## Dependencies
 
 *   [Agda compiler](https://agda.readthedocs.io/en/latest/getting-started/installation.html#installing-the-agda-and-the-agda-mode-programs).
-    Known to work with Agda 2.6.3, but not yet 2.6.4.
+    Works with Agda 2.6.4.
 *   The [Agda standard library (agda-stdlib)](https://github.com/agda/agda-stdlib).
-    Known to work with agda-stdlib 1.7.3, but not yet 2.0.
+    Works with agda-stdlib 2.0.
 *   Haskell [ieee754 package](https://github.com/agda/agda/issues/3619) (as described under Troubleshooting below).
 
 ## Troubleshooting

--- a/readme.md
+++ b/readme.md
@@ -9,9 +9,9 @@ This library replaces the overgrown [denotational-hardware](https://github.com/c
 ## Dependencies
 
 *   [Agda compiler](https://agda.readthedocs.io/en/latest/getting-started/installation.html#installing-the-agda-and-the-agda-mode-programs).
-    Known to work with Agda 2.6.3 but not yet 2.6.4.
+    Known to work with Agda 2.6.3, but not yet 2.6.4.
 *   The [Agda standard library (agda-stdlib)](https://github.com/agda/agda-stdlib).
-    Known to work with agda-stdlib 1.7.3 but not yet 2.0.
+    Known to work with agda-stdlib 1.7.3, but not yet 2.0.
 *   Haskell [ieee754 package](https://github.com/agda/agda/issues/3619) (as described under Troubleshooting below).
 
 ## Troubleshooting

--- a/src/Felix/Construct/Arrow.agda
+++ b/src/Felix/Construct/Arrow.agda
@@ -11,7 +11,7 @@ open import Felix.Homomorphism
 module Felix.Construct.Arrow
    {o}{obj : Set o}
    {ℓ} (_↠_ : obj → obj → Set ℓ) ⦃ _ : Category _↠_ ⦄
-   {q} ⦃ _ : Equivalent q _↠_ ⦄ ⦃ _ : L.Category _↠_ ⦄
+   {q} ⦃ eq : Equivalent q _↠_ ⦄ ⦃ _ : L.Category _↠_ ⦄
  where
 
 private
@@ -31,6 +31,7 @@ private
 open import Felix.Construct.Comma.Raw _↠_ _↠_ _↠_
               ⦃ catH₁ = catH ⦄ ⦃ catH₂ = catH ⦄ public
 
+open ≈-Reasoning ⦃ eq ⦄
 
 module arrow-products ⦃ p : Products obj ⦄ ⦃ c : Cartesian _↠_ ⦄ ⦃ lc : L.Cartesian _↠_ ⦄ where
 
@@ -54,7 +55,7 @@ module arrow-products ⦃ p : Products obj ⦄ ⦃ c : Cartesian _↠_ ⦄ ⦃ l
 
 -- Transposition
 _ᵀ : ∀ {a b} ((mkᵐ f₁ f₂ _) : a ↬ b) → (f₁ ⇉ f₂)
-_ᵀ {mkᵒ h} {mkᵒ h′} (mkᵐ _ _ commute) = mkᵐ h h′ (sym commute)
+_ᵀ {mkᵒ h} {mkᵒ h′} (mkᵐ _ _ commute) = mkᵐ h h′ (sym≈ commute)
 
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 

--- a/src/Felix/Construct/Comma/Homomorphism.agda
+++ b/src/Felix/Construct/Comma/Homomorphism.agda
@@ -11,9 +11,9 @@ module Felix.Construct.Comma.Homomorphism
    {o₀}{obj₀ : Set o₀} {ℓ₀} (_⇨₀_ : obj₀ → obj₀ → Set ℓ₀) ⦃ _ : Category _⇨₀_ ⦄
    {o₁}{obj₁ : Set o₁} {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄
    {o₂}{obj₂ : Set o₂} {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄
-   {q₀} ⦃ _ : Equivalent q₀ _⇨₀_ ⦄ ⦃ _ : L.Category _⇨₀_ ⦄
-   {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ -- ⦃ _ : L.Category _⇨₁_ ⦄
-   {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄ -- ⦃ _ : L.Category _⇨₂_ ⦄
+   {q₀} ⦃ eq₀ : Equivalent q₀ _⇨₀_ ⦄ ⦃ _ : L.Category _⇨₀_ ⦄
+   {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ -- ⦃ _ : L.Category _⇨₁_ ⦄
+   {q₂} ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄ -- ⦃ _ : L.Category _⇨₂_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₀ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₀_ ⦄
      ⦃ catH₁ : CategoryH _⇨₁_ _⇨₀_ ⦄
    ⦃ _ : Homomorphismₒ obj₂ obj₀ ⦄ ⦃ _ : Homomorphism _⇨₂_ _⇨₀_ ⦄
@@ -30,9 +30,11 @@ module comma-homomorphism-instances where
     open import Felix.Homomorphism
 
     categoryH₁ : CategoryH _↬_ _⇨₁_
-    categoryH₁ = record { F-cong = proj₁ ; F-id = refl ; F-∘ = refl }
+    categoryH₁ = record { F-cong = proj₁ ; F-id = refl≈ ; F-∘ = refl≈ }
+      where open ≈-Reasoning ⦃ eq₁ ⦄
 
     categoryH₂ : CategoryH _↬_ _⇨₂_
-    categoryH₂ = record { F-cong = proj₂ ; F-id = refl ; F-∘ = refl }
+    categoryH₂ = record { F-cong = proj₂ ; F-id = refl≈ ; F-∘ = refl≈ }
+      where open ≈-Reasoning ⦃ eq₂ ⦄
 
     -- Also CartesianH, CartesianClosedH, and LogicH

--- a/src/Felix/Construct/Comma/Raw.agda
+++ b/src/Felix/Construct/Comma/Raw.agda
@@ -7,16 +7,15 @@ open import Felix.Equiv
 open import Felix.Laws as L
        hiding (Category; Cartesian; CartesianClosed) -- ; Logic; Monoid
 open import Felix.Homomorphism
-open ≈-Reasoning
 open import Felix.Reasoning
 
 module Felix.Construct.Comma.Raw
    {o₀}{obj₀ : Set o₀} {ℓ₀} (_⇨₀_ : obj₀ → obj₀ → Set ℓ₀) ⦃ _ : Category _⇨₀_ ⦄
    {o₁}{obj₁ : Set o₁} {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄
    {o₂}{obj₂ : Set o₂} {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄
-   {q₀} ⦃ _ : Equivalent q₀ _⇨₀_ ⦄ ⦃ _ : L.Category _⇨₀_ ⦄
-   {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ -- ⦃ _ : L.Category _⇨₁_ ⦄
-   {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄ -- ⦃ _ : L.Category _⇨₂_ ⦄
+   {q₀} ⦃ eq₀ : Equivalent q₀ _⇨₀_ ⦄ ⦃ _ : L.Category _⇨₀_ ⦄
+   {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ -- ⦃ _ : L.Category _⇨₁_ ⦄
+   {q₂} ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄ -- ⦃ _ : L.Category _⇨₂_ ⦄
    ⦃ hₒ₁ : Homomorphismₒ obj₁ obj₀ ⦄ ⦃ h₁ : Homomorphism _⇨₁_ _⇨₀_ ⦄
      ⦃ catH₁ : CategoryH _⇨₁_ _⇨₀_ ⦄
    ⦃ hₒ₂ : Homomorphismₒ obj₂ obj₀ ⦄ ⦃ h₂ : Homomorphism _⇨₂_ _⇨₀_ ⦄
@@ -28,6 +27,7 @@ open import Felix.Construct.Comma.Type _⇨₀_ _⇨₁_ _⇨₂_
      public
 
 open Obj
+open ≈-Reasoning ⦃ eq₀ ⦄
 
 private variable a b c d : Obj
 
@@ -58,7 +58,7 @@ module comma-cat where
   --        (Fₘ g₂ ∘ h b) ∘ Fₘ f₁
   --      ≈⟨ ∘-assocʳ′ ↻-f ⟩
   --        Fₘ g₂ ∘ (Fₘ f₂ ∘ h a)
-  --      ≈⟨ ∘-assocˡ′ (sym F-∘) ⟩
+  --      ≈⟨ ∘-assocˡ′ (⟺ F-∘) ⟩
   --        Fₘ (g₂ ∘ f₂) ∘ h a
   --      ∎)
   -- -- 35s
@@ -66,7 +66,7 @@ module comma-cat where
   comp : (b ↬ c) → (a ↬ b) → (a ↬ c)
   comp (mkᵐ g₁ g₂ ↻-g) (mkᵐ f₁ f₂ ↻-f) =
     mkᵐ (g₁ ∘ f₁) (g₂ ∘ f₂)
-       (∘≈ʳ F-∘ ; ∘-assocˡ′ ↻-g ; ∘-assocʳ′ ↻-f ; ∘-assocˡ′ (sym F-∘))
+       (∘≈ʳ F-∘ ; ∘-assocˡ′ ↻-g ; ∘-assocʳ′ ↻-f ; ∘-assocˡ′ (sym≈ F-∘))
 
   instance
 
@@ -97,15 +97,15 @@ module comma-products
   --      (ε ∘ ε⁻¹) ∘ Fₘ !
   --    ≈⟨ ∘≈ʳ F-! ; cancelInner ε⁻¹∘ε ⟩
   --      ε ∘ !
-  --    ≈⟨ ∘≈ʳ (sym ∀⊤) ⟩
+  --    ≈⟨ ∘≈ʳ (sym≈ ∀⊤) ⟩
   --      ε ∘ (! ∘ h a)
-  --    ≈⟨ ∘-assocˡ′ (sym F-!) ⟩
+  --    ≈⟨ ∘-assocˡ′ (sym≈ F-!) ⟩
   --      Fₘ ! ∘ h a
   --    ∎)
   -- -- 23s
 
   !′ : a ↬ ⊤
-  !′ = mkᵐ ! ! (∘≈ʳ F-! ; cancelInner ε⁻¹∘ε ; ∘≈ʳ (sym ∀⊤) ; ∘-assocˡ′ (sym F-!))
+  !′ = mkᵐ ! ! (∘≈ʳ F-! ; cancelInner ε⁻¹∘ε ; ∘≈ʳ (sym≈ ∀⊤) ; ∘-assocˡ′ (sym≈ F-!))
 
   -- fork : (a ↬ c) → (a ↬ d) → (a ↬ c × d)
   -- fork {a}{c}{d} (mkᵐ f₁ f₂ ↻-f) (mkᵐ g₁ g₂ ↻-g) =
@@ -114,9 +114,9 @@ module comma-products
   --        h (c × d) ∘ Fₘ (f₁ ▵ g₁)
   --      ≈⟨ ∘≈ ∘-assocˡ F-▵ ; cancelInner μ⁻¹∘μ ⟩
   --        (μ ∘ (h c ⊗ h d)) ∘ (Fₘ f₁ ▵ Fₘ g₁)
-  --      ≈⟨ ∘-assocʳ′ (⊗∘▵ ; ▵≈ ↻-f ↻-g ; sym ▵∘) ⟩
+  --      ≈⟨ ∘-assocʳ′ (⊗∘▵ ; ▵≈ ↻-f ↻-g ; sym≈ ▵∘) ⟩
   --        μ ∘ ((Fₘ f₂ ▵ Fₘ g₂) ∘ h a)
-  --      ≈⟨ ∘-assocˡ′ (sym F-▵) ⟩
+  --      ≈⟨ ∘-assocˡ′ (sym≈ F-▵) ⟩
   --        Fₘ (f₂ ▵ g₂) ∘ h a
   --      ∎)
   -- -- 1m ?
@@ -126,8 +126,8 @@ module comma-products
     mkᵐ (f₁ ▵ g₁) (f₂ ▵ g₂)
        ( ∘≈ ∘-assocˡ F-▵
        ; cancelInner μ⁻¹∘μ
-       ; ∘-assocʳ′ (⊗∘▵ ; ▵≈ ↻-f ↻-g ; sym ▵∘)
-       ; ∘-assocˡ′ (sym F-▵)
+       ; ∘-assocʳ′ (⊗∘▵ ; ▵≈ ↻-f ↻-g ; sym≈ ▵∘)
+       ; ∘-assocˡ′ (sym≈ F-▵)
        )
 
   -- exl′ : a × b ↬ a
@@ -136,9 +136,9 @@ module comma-products
   --      h a ∘ Fₘ exl
   --    ≈⟨ ∘≈ʳ (introʳ μ∘μ⁻¹ ; ∘-assocˡ′ F-exl) ⟩
   --      h a ∘ (exl ∘ μ⁻¹)
-  --    ≈⟨ ∘-assocˡʳ′ (sym exl∘▵) ⟩
+  --    ≈⟨ ∘-assocˡʳ′ (sym≈ exl∘▵) ⟩
   --      exl ∘ (h a ⊗ h b) ∘ μ⁻¹
-  --    ≈⟨ sym (∘-assocˡ′ F-exl) ⟩
+  --    ≈⟨ sym≈ (∘-assocˡ′ F-exl) ⟩
   --      Fₘ exl ∘ μ ∘ (h a ⊗ h b) ∘ μ⁻¹
   --    ∎)
   -- -- 45s
@@ -146,8 +146,8 @@ module comma-products
   exl′ : a × b ↬ a
   exl′ = mkᵐ exl exl
     ( ∘≈ʳ (introʳ μ∘μ⁻¹ ; ∘-assocˡ′ F-exl)
-    ; ∘-assocˡʳ′ (sym exl∘▵)
-    ; sym (∘-assocˡ′ F-exl)
+    ; ∘-assocˡʳ′ (sym≈ exl∘▵)
+    ; sym≈ (∘-assocˡ′ F-exl)
     )
 
   -- exr′ : a × b ↬ b
@@ -156,9 +156,9 @@ module comma-products
   --      h b ∘ Fₘ exr
   --    ≈⟨ ∘≈ʳ (introʳ μ∘μ⁻¹ ; ∘-assocˡ′ F-exr) ⟩
   --      h b ∘ (exr ∘ μ⁻¹)
-  --    ≈⟨ ∘-assocˡʳ′ (sym exr∘▵) ⟩
+  --    ≈⟨ ∘-assocˡʳ′ (sym≈ exr∘▵) ⟩
   --      exr ∘ (h a ⊗ h b) ∘ μ⁻¹
-  --    ≈⟨ sym (∘-assocˡ′ F-exr) ⟩
+  --    ≈⟨ sym≈ (∘-assocˡ′ F-exr) ⟩
   --      Fₘ exr ∘ μ ∘ (h a ⊗ h b) ∘ μ⁻¹
   --    ∎)
   -- -- 45s
@@ -166,8 +166,8 @@ module comma-products
   exr′ : a × b ↬ b
   exr′ = mkᵐ exr exr
     ( ∘≈ʳ (introʳ μ∘μ⁻¹ ; ∘-assocˡ′ F-exr)
-    ; ∘-assocˡʳ′ (sym exr∘▵)
-    ; sym (∘-assocˡ′ F-exr)
+    ; ∘-assocˡʳ′ (sym≈ exr∘▵)
+    ; sym≈ (∘-assocˡ′ F-exr)
     )
 
   instance
@@ -212,7 +212,7 @@ module comma-products
 --   --    -- (β ∘ false ∘ ε⁻¹) ∘ (ε ∘ ε⁻¹)
 --   --    ≈˘⟨ (∘≈ˡ ∘-assocˡ ; cancelInner ε⁻¹∘ε ; ∘-assocʳ) ⟩
 --   --     (β ∘ false ∘ ε⁻¹) ∘ (ε ∘ ε⁻¹)
---   --    ≈⟨ ∘≈ˡ (sym F-false′) ⟩
+--   --    ≈⟨ ∘≈ˡ (sym≈ F-false′) ⟩
 --   --     Fₘ false ∘ (ε ∘ ε⁻¹)
 --   --    ≡⟨⟩
 --   --     Fₘ false ∘ h ⊤
@@ -222,14 +222,14 @@ module comma-products
 --   false′ = mkᵐ false false
 --     ( ∘≈ʳ F-false′
 --     ; ∘-assocˡ′ (∘-assoc-elimʳ β⁻¹∘β)
---     ; sym (∘≈ˡ (F-false′ ; ∘-assocˡ) ; cancelInner ε⁻¹∘ε ; ∘-assocʳ)
+--     ; sym≈ (∘≈ˡ (F-false′ ; ∘-assocˡ) ; cancelInner ε⁻¹∘ε ; ∘-assocʳ)
 --     )
 
 --   true′ : ⊤ ↬ Bool
 --   true′ = mkᵐ true true
 --     ( ∘≈ʳ F-true′
 --     ; ∘-assocˡ′ (∘-assoc-elimʳ β⁻¹∘β)
---     ; sym (∘≈ˡ (F-true′ ; ∘-assocˡ) ; cancelInner ε⁻¹∘ε ; ∘-assocʳ)
+--     ; sym≈ (∘≈ˡ (F-true′ ; ∘-assocˡ) ; cancelInner ε⁻¹∘ε ; ∘-assocʳ)
 --     )
 
 --   -- not′ = mkᵐ not not
@@ -241,7 +241,7 @@ module comma-products
 --   --      (β ∘ β⁻¹) ∘ (β ∘ not ∘ β⁻¹)
 --   --    ≈⟨ cancelInner β⁻¹∘β ⟩
 --   --      β ∘ not ∘ β⁻¹
---   --    ≈⟨ sym (∘-assocˡʳ′ F-not) ⟩
+--   --    ≈⟨ sym≈ (∘-assocˡʳ′ F-not) ⟩
 --   --      Fₘ not ∘ (β ∘ β⁻¹)
 --   --    ∎)
 
@@ -249,7 +249,7 @@ module comma-products
 --   not′ = mkᵐ not not
 --     ( ∘≈ʳ F-not′
 --     ; cancelInner β⁻¹∘β
---     ; sym (∘-assocˡʳ′ F-not)
+--     ; sym≈ (∘-assocˡʳ′ F-not)
 --     )
 
 --   -- ∧′ : Bool × Bool ↬ Bool
@@ -262,7 +262,7 @@ module comma-products
 --   --      (β ∘ β⁻¹) ∘ β ∘ ∧ ∘ (β⁻¹ ⊗ β⁻¹) ∘ μ⁻¹
 --   --    ≈⟨ ∘-assocˡ′ (∘-assoc-elimʳ β⁻¹∘β) ⟩
 --   --      β ∘ ∧ ∘ (β⁻¹ ⊗ β⁻¹) ∘ μ⁻¹
---   --    ≈⟨ ∘-assocˡ′ (sym F-∧) ⟩
+--   --    ≈⟨ ∘-assocˡ′ (sym≈ F-∧) ⟩
 --   --      (Fₘ ∧ ∘ μ ∘ (β ⊗ β)) ∘ (β⁻¹ ⊗ β⁻¹) ∘ μ⁻¹
 --   --    ≈⟨ ∘-assocʳ′ ∘-assocʳ ⟩
 --   --      Fₘ ∧ ∘ μ ∘ (β ⊗ β) ∘ (β⁻¹ ⊗ β⁻¹) ∘ μ⁻¹
@@ -278,7 +278,7 @@ module comma-products
 --   ∧′ = mkᵐ ∧ ∧
 --           ( ∘≈ʳ F-∧′
 --           ; ∘-assocˡ′ (∘-assoc-elimʳ β⁻¹∘β)
---           ; ∘-assocˡ′ (sym F-∧)
+--           ; ∘-assocˡ′ (sym≈ F-∧)
 --           ; ∘-assocʳ′ ∘-assocʳ
 --           ; ∘≈ʳ² (∘-assocˡ′ ⊗∘⊗)
 --           )
@@ -287,7 +287,7 @@ module comma-products
 --   ∨′ = mkᵐ ∨ ∨
 --           ( ∘≈ʳ F-∨′
 --           ; ∘-assocˡ′ (∘-assoc-elimʳ β⁻¹∘β)
---           ; ∘-assocˡ′ (sym F-∨)
+--           ; ∘-assocˡ′ (sym≈ F-∨)
 --           ; ∘-assocʳ′ ∘-assocʳ
 --           ; ∘≈ʳ² (∘-assocˡ′ ⊗∘⊗)
 --           )
@@ -296,7 +296,7 @@ module comma-products
 --   xor′ = mkᵐ xor xor
 --             ( ∘≈ʳ F-xor′
 --             ; ∘-assocˡ′ (∘-assoc-elimʳ β⁻¹∘β)
---             ; ∘-assocˡ′ (sym F-xor)
+--             ; ∘-assocˡ′ (sym≈ F-xor)
 --             ; ∘-assocʳ′ ∘-assocʳ
 --             ; ∘≈ʳ² (∘-assocˡ′ ⊗∘⊗)
 --             )
@@ -313,7 +313,7 @@ module comma-products
 --   --      cond ∘ (id ∘ β⁻¹ ⊗ ((h a ⊗ h a) ∘ μ⁻¹)) ∘ μ⁻¹
 --   --    ≈⟨ ∘≈ʳ (∘≈ˡ (⊗≈ˡ identityˡ)) ⟩
 --   --      cond ∘ (β⁻¹ ⊗ ((h a ⊗ h a) ∘ μ⁻¹)) ∘ μ⁻¹
---   --    ≈⟨ ∘≈ˡ (sym F-cond) ⟩
+--   --    ≈⟨ ∘≈ˡ (sym≈ F-cond) ⟩
 --   --      (Fₘ cond ∘ μ ∘ (β ⊗ μ)) ∘ (β⁻¹ ⊗ ((h a ⊗ h a) ∘ μ⁻¹)) ∘ μ⁻¹
 --   --    ≈⟨ ∘-assocʳ³ ⟩
 --   --      Fₘ cond ∘ μ ∘ (β ⊗ μ) ∘ (β⁻¹ ⊗ ((h a ⊗ h a) ∘ μ⁻¹)) ∘ μ⁻¹
@@ -334,7 +334,7 @@ module comma-products
 --     ( ∘≈ʳ F-cond′
 --     ; ∘-assocˡ′ f∘cond ; ∘-assocʳ
 --     ; ∘≈ʳ (∘-assocˡ′ ⊗∘⊗ ; ∘≈ˡ (⊗≈ˡ identityˡ))
---     ; ∘≈ˡ (sym F-cond)
+--     ; ∘≈ˡ (sym≈ F-cond)
 --     ; ∘-assocʳ³
 --     ; ∘≈ʳ² (∘-assocˡ ; ∘≈ˡ ⊗∘⊗)
 --     )

--- a/src/Felix/Construct/Product.agda
+++ b/src/Felix/Construct/Product.agda
@@ -102,9 +102,8 @@ module product-instances where instance
             e₂ = ∀× {f = f₂} {g₂} {k₂}
             module Q₁ = Equivalence e₁
             module Q₂ = Equivalence e₂
-            h₁ = Q₁.f ; h₁⁻¹ = Q₁.g
-            h₂ = Q₂.f ; h₂⁻¹ = Q₂.g
-            -- For agda-stdlib 2.0, fields 'f' and 'g' become 'to' and 'from'.
+            h₁ = Q₁.to ; h₁⁻¹ = Q₁.from
+            h₂ = Q₂.to ; h₂⁻¹ = Q₂.from
         in
         mk⇔
           (λ (z₁ , z₂) → let eq₁ , eq₁′ = h₁ z₁ ; eq₂ , eq₂′ = h₂ z₂ in

--- a/src/Felix/Construct/Product.agda
+++ b/src/Felix/Construct/Product.agda
@@ -66,16 +66,17 @@ module product-instances where instance
   --           ; cond  = cond  , cond
   --           }
 
-  equivalent : ∀ {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
+  equivalent : ∀ {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄
              → Equivalent (q₁ ⊔ q₂) _⇨_
-  equivalent = record
+  equivalent ⦃ eq₁ ⦄ ⦃ eq₂ ⦄ = record
     { _≈_ = λ (f₁ , f₂) (g₁ , g₂) → f₁ ≈ g₁ ×̇ f₂ ≈ g₂  -- Does this construction already exist?
     ; equiv = record
-       { refl  = refl , refl
-       ; sym   = λ (eq₁ , eq₂) → sym eq₁ , sym eq₂
-       ; trans = λ (eq₁ , eq₂) (eq₁′ , eq₂′)  → trans eq₁ eq₁′ , trans eq₂ eq₂′
+       { refl  = refl≈₁ , refl≈₂
+       ; sym   = λ (eq₁ , eq₂) → sym≈₁  eq₁ , sym≈₂  eq₂
+       ; trans = λ (eq₁ , eq₂) (eq₁′ , eq₂′) → (eq₁ ;₁ eq₁′) , (eq₂ ;₂ eq₂′)
        }
-    }
+    } where open ≈-Reasoning ⦃ eq₁ ⦄ renaming (refl≈ to refl≈₁; sym≈ to sym≈₁; _;_ to _;₁_)
+            open ≈-Reasoning ⦃ eq₂ ⦄ renaming (refl≈ to refl≈₂; sym≈ to sym≈₂; _;_ to _;₂_)
 
   l-category : ∀ {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
                ⦃ _ : L.Category _⇨₁_ ⦄ ⦃ _ : L.Category _⇨₂_ ⦄
@@ -140,11 +141,13 @@ module product-homomorphisms where instance
   H₂ : Homomorphism _⇨_ _⇨₂_
   H₂ = record { Fₘ = proj₂ }
 
-  catH₁ : ∀ {q₁ q₂} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ ⦃ _ : Equivalent q₂ _⇨₂_ ⦄ → CategoryH _⇨_ _⇨₁_
-  catH₁ = record { F-cong = proj₁ ; F-id = refl ; F-∘ = refl }
+  catH₁ : ∀ {q₁ q₂} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄ → CategoryH _⇨_ _⇨₁_
+  catH₁ ⦃ eq₁ ⦄ = record { F-cong = proj₁ ; F-id = refl≈ ; F-∘ = refl≈ }
+    where open ≈-Reasoning ⦃ eq₁ ⦄
 
-  catH₂ : ∀ {q₁ q₂} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ ⦃ _ : Equivalent q₂ _⇨₂_ ⦄ → CategoryH _⇨_ _⇨₂_
-  catH₂ = record { F-cong = proj₂ ; F-id = refl ; F-∘ = refl }
+  catH₂ : ∀ {q₁ q₂} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄ → CategoryH _⇨_ _⇨₂_
+  catH₂ ⦃ eq₂ = eq₂ ⦄ = record { F-cong = proj₂ ; F-id = refl≈ ; F-∘ = refl≈ }
+    where open ≈-Reasoning ⦃ eq₂ ⦄
 
   pH₁ : ∀ ⦃ _ : Products obj₁ ⦄ ⦃ _ : Products obj₂ ⦄ → ProductsH Obj _⇨₁_
   pH₁ = record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id }
@@ -170,25 +173,27 @@ module product-homomorphisms where instance
                 ; μ⁻¹∘μ = identityˡ
                 ; μ∘μ⁻¹ = identityˡ }
 
-  cartesianH₁ : ∀ {q₁ q₂} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
+  cartesianH₁ : ∀ {q₁ q₂} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
       ⦃ _ : Products  obj₁ ⦄ ⦃ _ : Products  obj₂ ⦄
       ⦃ _ : Cartesian _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄ ⦃ _ : L.Category _⇨₁_ ⦄
     → CartesianH _⇨_ _⇨₁_
-  cartesianH₁ = record
-    { F-!   = sym identityˡ
-    ; F-▵   = sym identityˡ
+  cartesianH₁ ⦃ eq₁ ⦄ = record
+    { F-!   = sym≈ identityˡ
+    ; F-▵   = sym≈ identityˡ
     ; F-exl = identityʳ
-    ; F-exr = identityʳ }
+    ; F-exr = identityʳ
+    } where open ≈-Reasoning ⦃ eq₁ ⦄
 
-  cartesianH₂ : ∀ {q₁ q₂} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
+  cartesianH₂ : ∀ {q₁ q₂} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄
       ⦃ _ : Products  obj₁ ⦄ ⦃ _ : Products  obj₂ ⦄
       ⦃ _ : Cartesian _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄ ⦃ _ : L.Category _⇨₂_ ⦄
     → CartesianH _⇨_ _⇨₂_
-  cartesianH₂ = record
-    { F-!   = sym identityˡ
-    ; F-▵   = sym identityˡ
+  cartesianH₂ ⦃ eq₂ = eq₂ ⦄ = record
+    { F-!   = sym≈ identityˡ
+    ; F-▵   = sym≈ identityˡ
     ; F-exl = identityʳ
-    ; F-exr = identityʳ }
+    ; F-exr = identityʳ
+    } where open ≈-Reasoning ⦃ eq₂ ⦄
 
 --   booleanH₁ :
 --       ∀ {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ ⦃ _ : Boolean obj₁ ⦄ ⦃ _ : Boolean obj₂ ⦄

--- a/src/Felix/Construct/Squared.agda
+++ b/src/Felix/Construct/Squared.agda
@@ -10,7 +10,7 @@ open import Felix.Laws as L
 module Felix.Construct.Squared
   {o} {obj : Set o} {ℓ} {_⇨_ : obj → obj → Set ℓ} ⦃ _ : Category _⇨_ ⦄
   ⦃ _ : Products obj ⦄ ⦃ _ : Cartesian _⇨_ ⦄
-  {q} ⦃ _ : Equivalent q _⇨_ ⦄ ⦃ _ : L.Category _⇨_ ⦄ ⦃ _ : L.Cartesian _⇨_ ⦄
+  {q} ⦃ eq : Equivalent q _⇨_ ⦄ ⦃ _ : L.Category _⇨_ ⦄ ⦃ _ : L.Cartesian _⇨_ ⦄
  where
 
 open import Data.Product using (_,_) renaming (map to _⊗̇_; uncurry to uncurry′)
@@ -26,6 +26,7 @@ unsquare = mk⤇ (λ (A , B) → A × B) (λ (f , g) → f ⊗ g)
 open import Felix.Reasoning
 
 module product-same-homomorphisms where instance
+  open ≈-Reasoning ⦃ eq ⦄
 
   Hₒ : Homomorphismₒ Obj obj
   Hₒ = toHₒ unsquare
@@ -36,7 +37,7 @@ module product-same-homomorphisms where instance
   -- H = record { Fₘ = λ (f , g) → f ⊗ g }
 
   catH : CategoryH _⇨²_ _⇨_
-  catH = record { F-cong = uncurry′ ⊗≈ ; F-id = id⊗id ; F-∘ = sym ⊗∘⊗ }
+  catH = record { F-cong = uncurry′ ⊗≈ ; F-id = id⊗id ; F-∘ = sym≈ ⊗∘⊗ }
 
   pH : ProductsH Obj _⇨_
   pH = record { ε = unitorⁱʳ ; μ = transpose ; ε⁻¹ = unitorᵉʳ ; μ⁻¹ = transpose }
@@ -49,14 +50,14 @@ module product-same-homomorphisms where instance
 
   cartH : CartesianH _⇨²_ _⇨_
   cartH = record { F-!   = !⊗!
-                 ; F-▵   = sym transpose∘▵⊗▵
+                 ; F-▵   = sym≈ transpose∘▵⊗▵
                  ; F-exl = [exl⊗exl]∘transpose
                  ; F-exr = [exr⊗exr]∘transpose }
 
   equivalent : Equivalent q _⇨²_
   equivalent = H-equiv
 
-  open import Felix.MakeLawful _⇨²_ _⇨_
+  open import Felix.MakeLawful _⇨²_ _⇨_ ⦃ product-instances.equivalent ⦄ ⦃ eq ⦄
 
-  catL : L.Category _⇨²_
+  catL : L.Category _⇨²_ ⦃ equiv = equivalent ⦄
   catL = LawfulCategoryᶠ

--- a/src/Felix/Equiv.agda
+++ b/src/Felix/Equiv.agda
@@ -23,8 +23,8 @@ record Equivalent q {obj : Set o} (_⇨_ : obj → obj → Set ℓ)
 
   module Equiv {a b} where
     open IsEquivalence (equiv {a}{b}) public
-      -- renaming (refl to refl≈; sym to sym≈; trans to trans≈)
-  open Equiv public
+
+  open Equiv
 
   ≈setoid : obj → obj → Setoid ℓ q
   ≈setoid a b = record { isEquivalence = equiv {a}{b} }
@@ -32,13 +32,19 @@ record Equivalent q {obj : Set o} (_⇨_ : obj → obj → Set ℓ)
   module ≈-Reasoning {a b} where
     open SetoidR (≈setoid a b) public
 
-  infixr 9 _•_
-  _•_ : {f g h : a ⇨ b} (g≈h : g ≈ h) (f≈g : f ≈ g) → f ≈ h
-  g≈h • f≈g = trans f≈g g≈h
+    refl≈ : {f : a ⇨ b} → f ≈ f
+    refl≈ = Equiv.refl
 
-  infixr 1 _;_   -- unicode
-  _;_ : {f g h : a ⇨ b} (f≈g : f ≈ g) (g≈h : g ≈ h) → f ≈ h
-  _;_ = trans
+    sym≈ : {f g : a ⇨ b} → f ≈ g → g ≈ f
+    sym≈ = Equiv.sym
+
+    infixr 9 _•_
+    _•_ : {f g h : a ⇨ b} (g≈h : g ≈ h) (f≈g : f ≈ g) → f ≈ h
+    g≈h • f≈g = Equiv.trans f≈g g≈h
+
+    infixr 1 _;_   -- unicode
+    _;_ : {f g h : a ⇨ b} (f≈g : f ≈ g) (g≈h : g ≈ h) → f ≈ h
+    _;_ = trans
 
 open Equivalent ⦃ … ⦄ public
 

--- a/src/Felix/Equiv.agda
+++ b/src/Felix/Equiv.agda
@@ -14,8 +14,6 @@ private
     obj : Set o
     a b : obj
 
--- TODO: move a and b arguments from methods to record.
-
 record Equivalent q {obj : Set o} (_⇨_ : obj → obj → Set ℓ)
        : Set (o ⊔ ℓ ⊔ suc q) where
   infix 4 _≈_
@@ -43,9 +41,6 @@ record Equivalent q {obj : Set o} (_⇨_ : obj → obj → Set ℓ)
   _;_ = trans
 
 open Equivalent ⦃ … ⦄ public
-
--- TODO: Replace Equivalent by Setoid?
--- I think we need _⇨_ as an argument rather than field.
 
 -- TODO: consider moving to Felix.Homomorphism.
 record Homomorphismₒ (obj₁ : Set o₁) (obj₂ : Set o₂) : Set (o₁ ⊔ o₂) where

--- a/src/Felix/Homomorphism.agda
+++ b/src/Felix/Homomorphism.agda
@@ -17,9 +17,6 @@ private
     obj₁ obj₂ : Set o
     a b c d : obj₁
 
-open ≈-Reasoning
-
-
 -- Category homomorphism (functor)
 record CategoryH
   {obj₁ : Set o₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄
@@ -35,6 +32,7 @@ record CategoryH
     -- TODO: make g and f explicit arguments? Wait and see.
 
   module _ ⦃ _ : L.Category _⇨₂_ ⦄ where
+    open ≈-Reasoning ⦃ eq₂ ⦄
 
     F-∘³ : {a₀ a₁ a₂ a₃ : obj₁}
            {f₁ : a₀ ⇨₁ a₁}{f₂ : a₁ ⇨₁ a₂}{f₃ : a₂ ⇨₁ a₃}
@@ -65,27 +63,29 @@ id-CategoryH : {obj : Set o} {_⇨_ : obj → obj → Set ℓ}
                {q : Level} ⦃ _ : Equivalent q _⇨_ ⦄
                ⦃ _ : Category _⇨_ ⦄
              → CategoryH _⇨_ _⇨_ ⦃ Hₒ = id-Hₒ ⦄ ⦃ H = id-H ⦄
-id-CategoryH = record { F-cong = id′ ; F-id = refl ; F-∘ = refl }
+id-CategoryH = record { F-cong = id′ ; F-id = refl≈ ; F-∘ = refl≈ }
+  where open ≈-Reasoning
 
 infixr 9 _∘-CategoryH_
 _∘-CategoryH_ :
    {obj₁ : Set o₁} {_⇨₁_ : obj₁ → obj₁ → Set ℓ₁}
    {obj₂ : Set o₂} {_⇨₂_ : obj₂ → obj₂ → Set ℓ₂}
    {obj₃ : Set o₃} {_⇨₃_ : obj₃ → obj₃ → Set ℓ₃}
-   {q₁ : Level} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄
-   {q₂ : Level} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
-   {q₃ : Level} ⦃ _ : Equivalent q₃ _⇨₃_ ⦄
+   {q₁ : Level} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄
+   {q₂ : Level} ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄
+   {q₃ : Level} ⦃ eq₃ : Equivalent q₃ _⇨₃_ ⦄
    ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Category _⇨₃_ ⦄
    ⦃ Fₒ : Homomorphismₒ obj₁ obj₂ ⦄ ⦃ Fₘ : Homomorphism _⇨₁_ _⇨₂_ ⦄
    ⦃ Gₒ : Homomorphismₒ obj₂ obj₃ ⦄ ⦃ Gₘ : Homomorphism _⇨₂_ _⇨₃_ ⦄
    (G : CategoryH _⇨₂_ _⇨₃_) (F : CategoryH _⇨₁_ _⇨₂_)
   → CategoryH _⇨₁_ _⇨₃_ ⦃ Hₒ = Gₒ ∘Hₒ Fₒ ⦄ ⦃ H = Gₘ ∘H Fₘ ⦄
-G ∘-CategoryH F  = record
+_∘-CategoryH_ ⦃ eq₃ = eq₃ ⦄ G F = record
   { F-cong = G.F-cong ∘̇ F.F-cong
   ; F-id   = G.F-cong F.F-id ; G.F-id
   ; F-∘    = G.F-cong F.F-∘  ; G.F-∘
-  }
- where module F = CategoryH F ; module G = CategoryH G
+  } where module F = CategoryH F
+          module G = CategoryH G
+          open ≈-Reasoning ⦃ eq₃ ⦄
 
 open import Data.Product using (_,_) renaming (_×_ to _×̇_; <_,_> to _▵̇_)
 
@@ -171,7 +171,7 @@ id-StrongProductsH =
 record CartesianH
   {obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄ (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁)
   {obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄ (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂)
-  {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
+  {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄
   ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
   ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
   ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
@@ -185,6 +185,7 @@ record CartesianH
     F-exr : ∀ {a b : obj₁} → Fₘ exr ∘ μ {a = a}{b} ≈ exr
 
   module _ ⦃ _ : L.Category _⇨₂_ ⦄ ⦃ spH : StrongProductsH obj₁ _⇨₂_ ⦄ where
+    open ≈-Reasoning ⦃ eq₂ ⦄
 
     F-!′ : {a : obj₁} → ε⁻¹ ∘ Fₘ {a = a} ! ≈ !
     F-!′ = ∘≈ʳ F-! ; ∘-assoc-elimˡ ε⁻¹∘ε
@@ -222,7 +223,7 @@ record CartesianH
           μ ∘ (Fₘ f ∘ Fₘ exl ▵ Fₘ g ∘ Fₘ exr)
         ≈⟨ ∘≈ʳ (▵≈ (∘≈ʳ F-exl′ ; ∘-assocˡ) (∘≈ʳ F-exr′ ; ∘-assocˡ)) ⟩
           μ ∘ ((Fₘ f ∘ exl) ∘ μ⁻¹ ▵ (Fₘ g ∘ exr) ∘ μ⁻¹)
-        ≈⟨ ∘≈ʳ (sym ▵∘) ⟩
+        ≈⟨ ∘≈ʳ (sym≈ ▵∘) ⟩
           μ ∘ (Fₘ f ∘ exl ▵ Fₘ g ∘ exr) ∘ μ⁻¹
         ∎
 
@@ -259,7 +260,7 @@ record CartesianH
           μ ∘ ((μ ∘ second (Fₘ exl)) ∘ second μ ▵ exr ∘ exr)
         ≈⟨ ∘≈ʳ (▵≈ˡ (∘-assocʳ′ (second∘⊗ ; ⊗≈ʳ F-exl))) ⟩
           μ ∘ (μ ∘ second exl ▵ exr ∘ exr)
-        ≈⟨ ∘≈ʳ (sym first∘▵) ⟩
+        ≈⟨ ∘≈ʳ (sym≈ first∘▵) ⟩
           μ ∘ first μ ∘ (second exl ▵ exr ∘ exr)
         ≡⟨⟩
           μ ∘ first μ ∘ assocˡ
@@ -270,7 +271,7 @@ record CartesianH
       F-assocˡ′ =
         begin
           Fₘ assocˡ
-        ≈⟨ sym (∘≈ʳ (∘≈ʳ (∘-assocˡ ; elimˡ (second-inverse μ∘μ⁻¹))) ; elimʳ μ∘μ⁻¹) ⟩
+        ≈⟨ sym≈ (∘≈ʳ (∘≈ʳ (∘-assocˡ ; elimˡ (second-inverse μ∘μ⁻¹))) ; elimʳ μ∘μ⁻¹) ⟩
           Fₘ assocˡ ∘ μ ∘ second μ ∘ second μ⁻¹ ∘ μ⁻¹
         ≈⟨ ∘-assocˡ³ ; ∘≈ˡ F-assocˡ ; ∘-assocʳ³ ⟩
           μ ∘ first μ ∘ assocˡ ∘ second μ⁻¹ ∘ μ⁻¹
@@ -305,7 +306,7 @@ record CartesianH
           μ ∘ (Fₘ exl ∘ μ ∘ exl ▵ μ ∘ first exr)
         ≈⟨ ∘≈ʳ (▵≈ˡ (∘-assocˡ′ F-exl)) ⟩
           μ ∘ (exl ∘ exl ▵ μ ∘ first exr)
-        ≈⟨ ∘≈ʳ (sym second∘▵) ⟩
+        ≈⟨ ∘≈ʳ (sym≈ second∘▵) ⟩
           μ ∘ second μ ∘ (exl ∘ exl ▵ first exr)
         ≡⟨⟩
           μ ∘ second μ ∘ assocʳ
@@ -316,7 +317,7 @@ record CartesianH
       F-assocʳ′ =
         begin
           Fₘ assocʳ
-        ≈⟨ sym (∘≈ʳ (∘≈ʳ (∘-assocˡ ; elimˡ (first-inverse μ∘μ⁻¹))) ; elimʳ μ∘μ⁻¹) ⟩
+        ≈⟨ sym≈ (∘≈ʳ (∘≈ʳ (∘-assocˡ ; elimˡ (first-inverse μ∘μ⁻¹))) ; elimʳ μ∘μ⁻¹) ⟩
           Fₘ assocʳ ∘ μ ∘ first μ ∘ first μ⁻¹ ∘ μ⁻¹
         ≈⟨ (∘-assocˡ³ ; ∘≈ˡ F-assocʳ ; ∘-assocʳ³) ⟩
           μ ∘ second μ ∘ assocʳ ∘ first μ⁻¹ ∘ μ⁻¹
@@ -331,11 +332,11 @@ id-CartesianH :
     ⦃ _ : L.Category _⇨_ ⦄ ⦃ _ : L.Cartesian _⇨_ ⦄
   → CartesianH _⇨_ _⇨_ ⦃ Hₒ = id-Hₒ ⦄ ⦃ H = id-H ⦄ ⦃ pH = id-ProductsH ⦄
 id-CartesianH = record
-  { F-!   = sym identityˡ
-  ; F-▵   = sym identityˡ
+  { F-!   = sym≈ identityˡ
+  ; F-▵   = sym≈ identityˡ
   ; F-exl = identityʳ
   ; F-exr = identityʳ
-  }
+  } where open ≈-Reasoning
 
 
 record CoproductsH

--- a/src/Felix/Instances/Function/Laws.agda
+++ b/src/Felix/Instances/Function/Laws.agda
@@ -13,7 +13,6 @@ open import Felix.Equiv
 open import Felix.Instances.Function.Raw ℓ public
 open import Axiom.Extensionality.Propositional
 open import Relation.Binary.PropositionalEquality
-     using (cong; cong₂)
      renaming ( refl to refl≡
               ; trans to trans≡
               ; sym to sym≡

--- a/src/Felix/Laws.agda
+++ b/src/Felix/Laws.agda
@@ -37,13 +37,13 @@ record Category {obj : Set o} (_⇨′_ : obj → obj → Set ℓ)
   ∘-assocʳ = assoc
 
   ∘-assocˡ : {f : a ⇨ b} {g : b ⇨ c} {h : c ⇨ d} → h ∘ (g ∘ f) ≈ (h ∘ g) ∘ f
-  ∘-assocˡ = sym ∘-assocʳ
+  ∘-assocˡ = sym≈ ∘-assocʳ
 
   ∘≈ˡ : ∀ {f : a ⇨ b} {h k : b ⇨ c} → h ≈ k → h ∘ f ≈ k ∘ f
-  ∘≈ˡ h≈k = ∘≈ h≈k refl
+  ∘≈ˡ h≈k = ∘≈ h≈k refl≈
 
   ∘≈ʳ : ∀ {f g : a ⇨ b} {h : b ⇨ c} → f ≈ g → h ∘ f ≈ h ∘ g
-  ∘≈ʳ f≈g = ∘≈ refl f≈g
+  ∘≈ʳ f≈g = ∘≈ refl≈ f≈g
 
 open Category ⦃ … ⦄ public
 
@@ -75,20 +75,20 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
   ∀×← = from ∀×
 
   ▵≈ˡ : {f : a ⇨ c} {h k : a ⇨ d} → h ≈ k → h ▵ f ≈ k ▵ f
-  ▵≈ˡ h≈k = ▵≈ h≈k refl
+  ▵≈ˡ h≈k = ▵≈ h≈k refl≈
 
   ▵≈ʳ : {f g : a ⇨ c} {h : a ⇨ d} → f ≈ g → h ▵ f ≈ h ▵ g
-  ▵≈ʳ f≈g = ▵≈ refl f≈g
+  ▵≈ʳ f≈g = ▵≈ refl≈ f≈g
 
   open import Data.Product using (proj₁; proj₂)
   -- TODO: Generalize Function category from level 0, and use exl & exr in place
   -- of proj₁ & proj₂
 
   exl∘▵ : {f : a ⇨ b} {g : a ⇨ c} → exl ∘ (f ▵ g) ≈ f
-  exl∘▵ = proj₁ (∀×→ refl)
+  exl∘▵ = proj₁ (∀×→ refl≈)
 
   exr∘▵ : {f : a ⇨ b} {g : a ⇨ c} → exr ∘ (f ▵ g) ≈ g
-  exr∘▵ = proj₂ (∀×→ refl)
+  exr∘▵ = proj₂ (∀×→ refl≈)
 
   -- Specializing:
   exl∘⊗ : {f : a ⇨ c} {g : b ⇨ d} → exl ∘ (f ⊗ g) ≈ f ∘ exl
@@ -109,7 +109,7 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
   exr∘second = exr∘⊗
 
   exl▵exr : {a b : obj} → exl ▵ exr ≈ id {a = a × b}
-  exl▵exr = sym (∀×← (identityʳ , identityʳ))
+  exl▵exr = sym≈ (∀×← (identityʳ , identityʳ))
 
   ⊗≈ : {a b c d : obj} {f g : a ⇨ c} {h k : b ⇨ d}
      → f ≈ g → h ≈ k → f ⊗ h ≈ g ⊗ k
@@ -128,17 +128,17 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
 
   ⊗≈ˡ : {a b c d : obj}{f g : a ⇨ c}{h : b ⇨ d}
      → f ≈ g → f ⊗ h ≈ g ⊗ h
-  ⊗≈ˡ f≈g = ⊗≈ f≈g refl
+  ⊗≈ˡ f≈g = ⊗≈ f≈g refl≈
 
   ⊗≈ʳ : {a b c d : obj}{f : a ⇨ c}{h k : b ⇨ d}
      → h ≈ k → f ⊗ h ≈ f ⊗ k
-  ⊗≈ʳ h≈k = ⊗≈ refl h≈k
+  ⊗≈ʳ h≈k = ⊗≈ refl≈ h≈k
 
   id⊗id : {a b : obj} → id ⊗ id ≈ id {a = a × b}
   id⊗id = exl▵exr • ▵≈ identityˡ identityˡ
 
   ▵∘ : {f : a ⇨ b} {g : b ⇨ c} {h : b ⇨ d} → (g ▵ h) ∘ f ≈ g ∘ f ▵ h ∘ f
-  ▵∘ {f = f}{g}{h}= ∀×← (∘≈ˡ exl∘▵ • sym assoc , ∘≈ˡ exr∘▵ • sym assoc)
+  ▵∘ {f = f}{g}{h}= ∀×← (∘≈ˡ exl∘▵ • sym≈ assoc , ∘≈ˡ exr∘▵ • sym≈ assoc)
 
   ⊗∘▵ : {f : a ⇨ b} {g : a ⇨ c} {h : b ⇨ d} {k : c ⇨ e}
       → (h ⊗ k) ∘ (f ▵ g) ≈ h ∘ f ▵ k ∘ g
@@ -210,7 +210,7 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
   unitorᵉʳ∘unitorⁱʳ = exl∘▵
 
   unitorⁱˡ∘unitorᵉˡ : ∀ {a : obj} → unitorⁱˡ ∘ unitorᵉˡ {a = a} ≈ id
-  unitorⁱˡ∘unitorᵉˡ = ▵∘ ; ▵≈ ∀⊤ identityˡ ; ▵≈ˡ (sym ∀⊤) ; exl▵exr
+  unitorⁱˡ∘unitorᵉˡ = ▵∘ ; ▵≈ ∀⊤ identityˡ ; ▵≈ˡ (sym≈ ∀⊤) ; exl▵exr
 
   --   (! ▵ id) ∘ exr
   -- ≈ ! ∘ exr ▵ id ∘ exr
@@ -219,7 +219,7 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
   -- ≈ id
 
   unitorⁱʳ∘unitorᵉʳ : ∀ {a : obj} → unitorⁱʳ ∘ unitorᵉʳ {a = a} ≈ id
-  unitorⁱʳ∘unitorᵉʳ = ▵∘ ; ▵≈ identityˡ ∀⊤ ; ▵≈ʳ (sym ∀⊤) ; exl▵exr
+  unitorⁱʳ∘unitorᵉʳ = ▵∘ ; ▵≈ identityˡ ∀⊤ ; ▵≈ʳ (sym≈ ∀⊤) ; exl▵exr
 
   --   (id ▵ !) ∘ exl
   -- ≈ id ∘ exl ▵ ! ∘ exl

--- a/src/Felix/Laws.agda
+++ b/src/Felix/Laws.agda
@@ -272,7 +272,6 @@ open Cartesian ⦃ … ⦄ public
 record CartesianClosed {obj : Set o} ⦃ _ : Products obj ⦄
                        ⦃ _ : Exponentials obj ⦄ (_⇨′_ : obj → obj → Set ℓ)
                        {q} ⦃ _ : Equivalent q _⇨′_ ⦄
-                       ⦃ _ : Products (Set q) ⦄
                        ⦃ _ : R.Category _⇨′_ ⦄
                        ⦃ _ : R.Cartesian _⇨′_ ⦄
                        ⦃ _ : R.CartesianClosed _⇨′_ ⦄

--- a/src/Felix/Laws.agda
+++ b/src/Felix/Laws.agda
@@ -68,11 +68,11 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
 
   ∀×→ : {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
      → k ≈ f ▵ g → (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g)
-  ∀×→ = f ∀×  -- For agda-stdlib 2.0: to ∀×
+  ∀×→ = to ∀×
 
   ∀×← : {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
      → (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g) → k ≈ f ▵ g
-  ∀×← = g ∀×  -- For agda-stdlib 2.0: from ∀×
+  ∀×← = from ∀×
 
   ▵≈ˡ : {f : a ⇨ c} {h k : a ⇨ d} → h ≈ k → h ▵ f ≈ k ▵ f
   ▵≈ˡ h≈k = ▵≈ h≈k refl
@@ -288,11 +288,11 @@ record CartesianClosed {obj : Set o} ⦃ _ : Products obj ⦄
 
   ∀⇛→ : {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)}
       → g ≈ curry f → f ≈ uncurry g
-  ∀⇛→ = f ∀⇛  -- For agda-stdlib 2.0: to ∀⇛
+  ∀⇛→ = to ∀⇛
 
   ∀⇛← : {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)}
       → f ≈ uncurry g → g ≈ curry f
-  ∀⇛← = g ∀⇛  -- For agda-stdlib 2.0: from ∀⇛
+  ∀⇛← = from ∀⇛
 
   curry-apply : {a b : obj} → id { a = a ⇛ b } ≈ curry apply
   curry-apply = ∀⇛← (begin

--- a/src/Felix/MakeLawful.agda
+++ b/src/Felix/MakeLawful.agda
@@ -10,7 +10,7 @@ open import Felix.Homomorphism
 module Felix.MakeLawful
          {o₁}{obj₁ : Set o₁} {ℓ₁}(_⇨₁_ : obj₁ → obj₁ → Set ℓ₁)
          {o₂}{obj₂ : Set o₂} {ℓ₂}(_⇨₂_ : obj₂ → obj₂ → Set ℓ₂)
-         {q₁} ⦃ _ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ _ : Equivalent q₂ _⇨₂_ ⦄
+         {q₁} ⦃ eq₁ : Equivalent q₁ _⇨₁_ ⦄ {q₂} ⦃ eq₂ : Equivalent q₂ _⇨₂_ ⦄
          ⦃ _ : Homomorphismₒ obj₁ obj₂ ⦄
          ⦃ H : Homomorphism _⇨₁_ _⇨₂_ ⦄
  where
@@ -21,7 +21,7 @@ open import Felix.Raw
 open import Felix.Laws as L hiding (Category; Cartesian; CartesianClosed)
 open import Felix.Reasoning
 
-open ≈-Reasoning
+open ≈-Reasoning ⦃ eq₂ ⦄
 
 private
   variable
@@ -125,24 +125,24 @@ LawfulCartesianᶠ = record
         ≈⟨ exr∘▵ ⟩
           Fₘ g
         ∎))
-      (λ (exl∘k≈f , exr∘k≈g) → sym (begin
+      (λ (exl∘k≈f , exr∘k≈g) → sym≈ (begin
           Fₘ (f ▵ g)
         ≈⟨ F-▵ ⟩
           μ ∘ (Fₘ f ▵ Fₘ g)
-        ≈⟨ ∘≈ʳ (▵≈ (sym exl∘k≈f ; F-∘) (sym exr∘k≈g ; F-∘)) ⟩
+        ≈⟨ ∘≈ʳ (▵≈ (sym≈ exl∘k≈f ; F-∘) (sym≈ exr∘k≈g ; F-∘)) ⟩
           μ ∘ ((Fₘ exl ∘ Fₘ k) ▵ (Fₘ exr ∘ Fₘ k))
-        ≈⟨ ∘≈ʳ (sym ▵∘) ⟩
+        ≈⟨ ∘≈ʳ (sym≈ ▵∘) ⟩
           μ ∘ (Fₘ exl ▵ Fₘ exr) ∘ Fₘ k
         ≈⟨ ∘≈ʳ (∘≈ˡ (▵≈ F-exl′ F-exr′)) ⟩
           μ ∘ (exl ∘ μ⁻¹ ▵ exr ∘ μ⁻¹) ∘ Fₘ k
-        ≈⟨ ∘≈ʳ (∘≈ˡ (sym ▵∘)) ⟩
+        ≈⟨ ∘≈ʳ (∘≈ˡ (sym≈ ▵∘)) ⟩
           μ ∘ ((exl ▵ exr) ∘ μ⁻¹) ∘ Fₘ k
         ≈⟨ ∘≈ʳ (∘≈ˡ (elimˡ exl▵exr)) ⟩
           μ ∘ μ⁻¹ ∘ Fₘ k
         ≈⟨ cancelˡ μ∘μ⁻¹ ⟩
           Fₘ k
         ∎))
-    ; ▵≈ = λ h≈k f≈g → F-▵ ; ∘≈ʳ (▵≈ h≈k f≈g) ; sym F-▵
+    ; ▵≈ = λ h≈k f≈g → F-▵ ; ∘≈ʳ (▵≈ h≈k f≈g) ; sym≈ F-▵
   }
 
 -- TODO: CartesianClosed, etc.

--- a/src/Felix/Reasoning.agda
+++ b/src/Felix/Reasoning.agda
@@ -28,11 +28,11 @@ open ≈-Reasoning
 
 module Misc where
 
-  sym-sym : {i j : a ⇨ b} {f g : c ⇨ d} → (i ≈ j → f ≈ g) → (j ≈ i → g ≈ f)
-  sym-sym f≈g = sym ∘′ f≈g ∘′ sym
-  -- sym-sym f≈g i≈j = sym (f≈g (sym i≈j))
+  sym≈-sym≈ : {i j : a ⇨ b} {f g : c ⇨ d} → (i ≈ j → f ≈ g) → (j ≈ i → g ≈ f)
+  sym≈-sym≈ f≈g = sym≈ ∘′ f≈g ∘′ sym≈
+  -- sym≈-sym≈ f≈g i≈j = sym≈ (f≈g (sym≈ i≈j))
 
-  -- I've been able to use sym-sym, due to implicits
+  -- I've been able to use sym≈-sym≈, due to implicits
 
 open Misc public
 
@@ -49,7 +49,7 @@ module IntroElim {i : b ⇨ b} (i≈id : i ≈ id) where
                    ∎
 
   introˡ : ∀ {f : a ⇨ b} → f ≈ i ∘ f
-  introˡ = sym elimˡ
+  introˡ = sym≈ elimˡ
 
   elimʳ  : ∀ {f : b ⇨ c} → f ∘ i ≈ f
   elimʳ  {f = f} = begin
@@ -61,13 +61,13 @@ module IntroElim {i : b ⇨ b} (i≈id : i ≈ id) where
                    ∎
 
   introʳ : ∀ {f : b ⇨ c} → f ≈ f ∘ i
-  introʳ = sym elimʳ
+  introʳ = sym≈ elimʳ
 
   elim-center  : ∀ {f : a ⇨ b} {g : b ⇨ c} → g ∘ i ∘ f ≈ g ∘ f
   elim-center = ∘≈ʳ elimˡ
 
   intro-center : ∀ {f : a ⇨ b} {g : b ⇨ c} → g ∘ f ≈ g ∘ i ∘ f
-  intro-center  = sym elim-center
+  intro-center  = sym≈ elim-center
 
 open IntroElim public
 
@@ -126,24 +126,24 @@ module ∘-Assoc where
   ∘-assocˡ³ : {a₀ a₁ a₂ a₃ a₄ : obj}
            {f₁ : a₀ ⇨ a₁}{f₂ : a₁ ⇨ a₂}{f₃ : a₂ ⇨ a₃}{f₄ : a₃ ⇨ a₄}
          → f₄ ∘ f₃ ∘ f₂ ∘ f₁ ≈ (f₄ ∘ f₃ ∘ f₂) ∘ f₁
-  ∘-assocˡ³ = sym ∘-assocʳ³
+  ∘-assocˡ³ = sym≈ ∘-assocʳ³
 
   ∘-assocˡ⁴ : {a₀ a₁ a₂ a₃ a₄ a₅ : obj}
      {f₁ : a₀ ⇨ a₁}{f₂ : a₁ ⇨ a₂}{f₃ : a₂ ⇨ a₃}{f₄ : a₃ ⇨ a₄}{f₅ : a₄ ⇨ a₅}
    → f₅ ∘ f₄ ∘ f₃ ∘ f₂ ∘ f₁ ≈ (f₅ ∘ f₄ ∘ f₃ ∘ f₂) ∘ f₁
-  ∘-assocˡ⁴ = sym ∘-assocʳ⁴
+  ∘-assocˡ⁴ = sym≈ ∘-assocʳ⁴
 
   ∘-assocˡ⁵ : {a₀ a₁ a₂ a₃ a₄ a₅ a₆ : obj}
      {f₁ : a₀ ⇨ a₁}{f₂ : a₁ ⇨ a₂}{f₃ : a₂ ⇨ a₃}{f₄ : a₃ ⇨ a₄}{f₅ : a₄ ⇨ a₅}
        {f₆ : a₅ ⇨ a₆}
    → f₆ ∘ f₅ ∘ f₄ ∘ f₃ ∘ f₂ ∘ f₁ ≈ (f₆ ∘ f₅ ∘ f₄ ∘ f₃ ∘ f₂) ∘ f₁
-  ∘-assocˡ⁵ = sym ∘-assocʳ⁵
+  ∘-assocˡ⁵ = sym≈ ∘-assocʳ⁵
 
   ∘-assocˡ⁶ : {a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇ : obj}
      {f₁ : a₀ ⇨ a₁}{f₂ : a₁ ⇨ a₂}{f₃ : a₂ ⇨ a₃}{f₄ : a₃ ⇨ a₄}{f₅ : a₄ ⇨ a₅}
        {f₆ : a₅ ⇨ a₆}{f₇ : a₆ ⇨ a₇}
    → f₇ ∘ f₆ ∘ f₅ ∘ f₄ ∘ f₃ ∘ f₂ ∘ f₁ ≈ (f₇ ∘ f₆ ∘ f₅ ∘ f₄ ∘ f₃ ∘ f₂) ∘ f₁
-  ∘-assocˡ⁶ = sym ∘-assocʳ⁶
+  ∘-assocˡ⁶ = sym≈ ∘-assocʳ⁶
 
   ∘≈ʳ² : ∀ {a₀ a₁ a₂ a₃ : obj}{f₁ g₁ : a₀ ⇨ a₁}{f₂ : a₁ ⇨ a₂}{f₃ : a₂ ⇨ a₃}
     → f₁ ≈ g₁ → f₃ ∘ f₂ ∘ f₁ ≈ f₃ ∘ f₂ ∘ g₁
@@ -188,7 +188,7 @@ module Cancel {i : b ⇨ c} {h : c ⇨ b} (inv : h ∘ i ≈ id) where
     ∎
 
   -- insertʳ : {f : b ⇨ d} → f ≈ (f ∘ h) ∘ i
-  -- insertʳ = sym cancelʳ
+  -- insertʳ = sym≈ cancelʳ
 
   cancelˡ : {f : a ⇨ b} →  h ∘ (i ∘ f) ≈ f
   cancelˡ {f = f} =
@@ -201,7 +201,7 @@ module Cancel {i : b ⇨ c} {h : c ⇨ b} (inv : h ∘ i ≈ id) where
     ∎
 
   -- insertˡ : {f : a ⇨ b} →  f ≈ h ∘ (i ∘ f)
-  -- insertˡ = Equiv.sym cancelˡ
+  -- insertˡ = Equiv.sym≈ cancelˡ
 
   cancelInner : {f : b ⇨ d} {g : a ⇨ b} → (f ∘ h) ∘ (i ∘ g) ≈ f ∘ g
   cancelInner {f = f} {g = g} =
@@ -255,10 +255,10 @@ module Assoc
     -- -- Likewise below. For faster compiles, but maybe not worth it.
     ≈⟨ ▵≈ (second∘▵ ; ▵≈ʳ exl∘⊗) (∘-assocʳ ; ∘≈ʳ exr∘▵ ; exr∘first) ⟩
       (exl ∘ exl ▵ exr ∘ exl) ▵ exr
-    -- ≈⟨ ▵≈ˡ (sym ▵∘) ⟩
+    -- ≈⟨ ▵≈ˡ (sym≈ ▵∘) ⟩
     --   (exl ▵ exr) ∘ exl ▵ exr
     -- ≈⟨ ▵≈ˡ (∘≈ˡ exl▵exr ; identityˡ) ⟩
-    ≈⟨ ▵≈ˡ (sym ▵∘ ; elimˡ exl▵exr) ⟩
+    ≈⟨ ▵≈ˡ (sym≈ ▵∘ ; elimˡ exl▵exr) ⟩
       exl ▵ exr
     ≈⟨ exl▵exr ⟩
       id
@@ -277,7 +277,7 @@ module Assoc
     -- ≈⟨ ▵≈ (∘≈ʳ exl∘▵) (▵≈ˡ exr∘second) ⟩
     ≈⟨ ▵≈ (∘-assocʳ ; ∘≈ʳ exl∘▵) (first∘▵ ; ▵≈ˡ exr∘second) ⟩
       exl ∘ second exl ▵ (exl ∘ exr ▵ exr ∘ exr)
-    ≈⟨ ▵≈ exl∘second (sym ▵∘) ⟩
+    ≈⟨ ▵≈ exl∘second (sym≈ ▵∘) ⟩
       exl ▵ (exl ▵ exr) ∘ exr
     ≈⟨ ▵≈ʳ (elimˡ exl▵exr) ⟩
       exl ▵ exr
@@ -328,19 +328,19 @@ module Assoc
       f ∘ exl ∘ exl ▵ (g ⊗ h) ∘ first exr
     -- ≈⟨ ▵≈ʳ ⊗∘first ⟩
     --   f ∘ exl ∘ exl ▵ (g ∘ exr ⊗ h)
-    -- ≈⟨ ▵≈ʳ (⊗≈ˡ (sym exr∘⊗)) ⟩
+    -- ≈⟨ ▵≈ʳ (⊗≈ˡ (sym≈ exr∘⊗)) ⟩
     --   f ∘ exl ∘ exl ▵ (exr ∘ (f ⊗ g) ⊗ h)
-    -- ≈⟨ ▵≈ʳ (sym first∘⊗) ⟩
-    ≈⟨ ▵≈ʳ (⊗∘first ; ⊗≈ˡ (sym exr∘⊗) ; sym first∘⊗) ⟩
+    -- ≈⟨ ▵≈ʳ (sym≈ first∘⊗) ⟩
+    ≈⟨ ▵≈ʳ (⊗∘first ; ⊗≈ˡ (sym≈ exr∘⊗) ; sym≈ first∘⊗) ⟩
       f ∘ exl ∘ exl ▵ first exr ∘ ((f ⊗ g) ⊗ h)
-    -- ≈⟨ ▵≈ˡ (∘-assocˡʳ′ (sym exl∘⊗)) ⟩
+    -- ≈⟨ ▵≈ˡ (∘-assocˡʳ′ (sym≈ exl∘⊗)) ⟩
     --   exl ∘ (f ⊗ g) ∘ exl ▵ first exr ∘ ((f ⊗ g) ⊗ h)
-    -- ≈⟨ ▵≈ˡ (∘≈ʳ (sym exl∘⊗)) ⟩
+    -- ≈⟨ ▵≈ˡ (∘≈ʳ (sym≈ exl∘⊗)) ⟩
     --   exl ∘ exl ∘ ((f ⊗ g) ⊗ h) ▵ first exr ∘ ((f ⊗ g) ⊗ h)
     -- ≈⟨ ▵≈ˡ ∘-assocˡ ⟩
-    ≈⟨ ▵≈ˡ (∘-assocˡʳ′ (sym exl∘⊗) ; ∘≈ʳ (sym exl∘⊗) ; ∘-assocˡ) ⟩
+    ≈⟨ ▵≈ˡ (∘-assocˡʳ′ (sym≈ exl∘⊗) ; ∘≈ʳ (sym≈ exl∘⊗) ; ∘-assocˡ) ⟩
       (exl ∘ exl) ∘ ((f ⊗ g) ⊗ h) ▵ first exr ∘ ((f ⊗ g) ⊗ h)
-    ≈⟨ sym ▵∘ ⟩
+    ≈⟨ sym≈ ▵∘ ⟩
       (exl ∘ exl ▵ first exr) ∘ ((f ⊗ g) ⊗ h)
     ≡⟨⟩
       assocʳ ∘ ((f ⊗ g) ⊗ h)
@@ -357,17 +357,17 @@ module Assoc
       (f ⊗ g) ∘ second exl ▵ h ∘ exr ∘ exr
     -- ≈⟨ ▵≈ˡ ⊗∘second ⟩
     --   (f ⊗ g ∘ exl) ▵ h ∘ exr ∘ exr
-    -- ≈⟨ ▵≈ˡ (⊗≈ʳ (sym exl∘⊗)) ⟩
-    ≈⟨ ▵≈ˡ (⊗∘second ; ⊗≈ʳ (sym exl∘⊗)) ⟩
+    -- ≈⟨ ▵≈ˡ (⊗≈ʳ (sym≈ exl∘⊗)) ⟩
+    ≈⟨ ▵≈ˡ (⊗∘second ; ⊗≈ʳ (sym≈ exl∘⊗)) ⟩
       (f ⊗ exl ∘ (g ⊗ h)) ▵ h ∘ exr ∘ exr
-    -- ≈⟨ ▵≈ʳ (∘-assocˡʳ′ (sym exr∘⊗)) ⟩
+    -- ≈⟨ ▵≈ʳ (∘-assocˡʳ′ (sym≈ exr∘⊗)) ⟩
     --   (f ⊗ exl ∘ (g ⊗ h)) ▵ exr ∘ (g ⊗ h) ∘ exr
-    -- ≈⟨ ▵≈ʳ (∘≈ʳ (sym exr∘⊗)) ⟩
-    ≈⟨ ▵≈ʳ (∘-assocˡʳ′ (sym exr∘⊗) ; ∘≈ʳ (sym exr∘⊗)) ⟩
+    -- ≈⟨ ▵≈ʳ (∘≈ʳ (sym≈ exr∘⊗)) ⟩
+    ≈⟨ ▵≈ʳ (∘-assocˡʳ′ (sym≈ exr∘⊗) ; ∘≈ʳ (sym≈ exr∘⊗)) ⟩
       (f ⊗ exl ∘ (g ⊗ h)) ▵ exr ∘ exr ∘ (f ⊗ (g ⊗ h))
-    ≈⟨ ▵≈ (sym second∘⊗) ∘-assocˡ ⟩
+    ≈⟨ ▵≈ (sym≈ second∘⊗) ∘-assocˡ ⟩
       second exl ∘ (f ⊗ (g ⊗ h)) ▵ (exr ∘ exr) ∘ (f ⊗ (g ⊗ h))
-    ≈⟨ sym ▵∘ ⟩
+    ≈⟨ sym≈ ▵∘ ⟩
       (second exl ▵ exr ∘ exr) ∘ (f ⊗ (g ⊗ h))
     ≡⟨⟩
       assocˡ ∘ (f ⊗ (g ⊗ h))
@@ -395,7 +395,7 @@ module Assoc
   first-first {f = f} =
     begin
       first (first f)
-    ≈⟨ sym (elimʳ assocˡ∘assocʳ) ⟩
+    ≈⟨ sym≈ (elimʳ assocˡ∘assocʳ) ⟩
       first (first f) ∘ assocˡ ∘ assocʳ
     ≈⟨ ∘-assocˡʳ′ first-first∘assocˡ ⟩
       assocˡ ∘ first f ∘ assocʳ
@@ -463,9 +463,9 @@ module Assoc
       ! ∘ exl ▵ ! ∘ exr
     ≈⟨ ▵≈ ∀⊤ ∀⊤ ⟩
       ! ▵ !
-    ≈⟨ sym (▵≈ ∀⊤ ∀⊤) ⟩
+    ≈⟨ sym≈ (▵≈ ∀⊤ ∀⊤) ⟩
       id ∘ ! ▵ ! ∘ !
-    ≈⟨ sym ▵∘ ⟩
+    ≈⟨ sym≈ ▵∘ ⟩
       (id ▵ !) ∘ !
     ≡⟨⟩
       unitorⁱʳ ∘ !
@@ -482,7 +482,7 @@ module Assoc
       exl ∘ (exl ∘ exl ▵ exl ∘ exr) ▵ exl ∘ (exr ∘ exl ▵ exr ∘ exr)
     ≈⟨ ▵≈ exl∘▵ exl∘▵ ⟩
       exl ∘ exl ▵ exr ∘ exl
-    ≈⟨ sym ▵∘ ⟩
+    ≈⟨ sym≈ ▵∘ ⟩
       (exl ▵ exr) ∘ exl
     ≈⟨ elimˡ exl▵exr ⟩
       exl
@@ -499,7 +499,7 @@ module Assoc
       exr ∘ (exl ∘ exl ▵ exl ∘ exr) ▵ exr ∘ (exr ∘ exl ▵ exr ∘ exr)
     ≈⟨ ▵≈ exr∘▵ exr∘▵ ⟩
       exl ∘ exr ▵ exr ∘ exr
-    ≈⟨ sym ▵∘ ⟩
+    ≈⟨ sym≈ ▵∘ ⟩
       (exl ▵ exr) ∘ exr
     ≈⟨ elimˡ exl▵exr ⟩
       exr
@@ -543,7 +543,7 @@ module Assoc
       transpose ∘ ((f₁ ∘ exl ▵ f₂ ∘ exr) ▵ (g₁ ∘ exl ▵ g₂ ∘ exr))
     ≈⟨ transpose∘▵▵▵ ⟩
       ((f₁ ∘ exl ▵ g₁ ∘ exl) ▵ (f₂ ∘ exr ▵ g₂ ∘ exr))
-    ≈⟨ sym (▵≈ ▵∘ ▵∘) ⟩
+    ≈⟨ sym≈ (▵≈ ▵∘ ▵∘) ⟩
       ((f₁ ▵ g₁) ∘ exl ▵ (f₂ ▵ g₂) ∘ exr)
     ≡⟨⟩
       (f₁ ▵ g₁) ⊗ (f₂ ▵ g₂)
@@ -558,7 +558,7 @@ module Assoc
       transpose ∘ ((exl ∘ exl ▵ exl ∘ exr) ▵ (exr ∘ exl ▵ exr ∘ exr))
     ≈⟨ transpose∘▵▵▵ ⟩
       ((exl ∘ exl ▵ exr ∘ exl) ▵ (exl ∘ exr ▵ exr ∘ exr))
-    ≈⟨ sym (▵≈ ▵∘ ▵∘) ⟩
+    ≈⟨ sym≈ (▵≈ ▵∘ ▵∘) ⟩
       ((exl ▵ exr) ∘ exl ▵ (exl ▵ exr) ∘ exr)
     ≈⟨ ▵≈ (elimˡ exl▵exr) (elimˡ exl▵exr) ⟩
       exl ▵ exr

--- a/src/Felix/Subcategory/Morphism.agda
+++ b/src/Felix/Subcategory/Morphism.agda
@@ -17,6 +17,7 @@ module Felix.Subcategory.Morphism {o ℓ} {obj : Set o}
 private variable a b c d : obj
 
 open import Felix.Prop
+open ≈-Reasoning
 
 infix 0 _⇨_
 record _⇨_ (a b : obj) : Set (ℓ ⊔ m) where
@@ -27,12 +28,12 @@ record _⇨_ (a b : obj) : Set (ℓ ⊔ m) where
 
 private
   refl↠ : {f : a ↠ b} → f ≈ f
-  refl↠ = refl
+  refl↠ = refl≈
 
   sym-identityˡ↠ : ⦃ _ : Products obj ⦄ ⦃ _ : Cartesian _↠_ ⦄
     ⦃ _ : L.Category _↠_ ⦄ ⦃ _ : L.Cartesian _↠_ ⦄ {f : a ↠ b} →
     f ≈ id ∘ f
-  sym-identityˡ↠ = sym L.identityˡ
+  sym-identityˡ↠ = sym≈ L.identityˡ
 
 module subcat-instances ⦃ _ : Categoryᴾ M ⦄ where instance
 

--- a/src/Felix/Subcategory/Object.agda
+++ b/src/Felix/Subcategory/Object.agda
@@ -23,6 +23,8 @@ module Felix.Subcategory.Object
   ⦃ Hₒ : Homomorphismₒ J obj ⦄
  where
 
+open ≈-Reasoning
+
 infix 0 _⇨_
 record _⇨_ (a b : J) : Set ℓ where
   constructor mk
@@ -66,8 +68,8 @@ module subcategory-instances where instance
 
   module _ {q : Level} ⦃ _ : Equivalent q _↠_ ⦄ where
 
-    refl↠ : ∀ {a b}{f : a ↠ b} → f ≈ f
-    refl↠ = refl
+    refl≈↠ : ∀ {a b}{f : a ↠ b} → f ≈ f
+    refl≈↠ = refl≈
 
     instance
 
@@ -75,14 +77,14 @@ module subcategory-instances where instance
       equivalent = H-equiv
 
       categoryH : CategoryH _⇨_ _↠_
-      categoryH = record { F-cong = λ ~ → ~ ; F-id = refl↠ ; F-∘ = refl↠ }
+      categoryH = record { F-cong = λ ~ → ~ ; F-id = refl≈↠ ; F-∘ = refl≈↠ }
 
       cartesianH :
         ⦃ _ : Products obj ⦄ ⦃ _ : Cartesian _↠_ ⦄ ⦃ _ : L.Category _↠_ ⦄
         ⦃ _ : Products J ⦄ ⦃ _ : ProductsH J _↠_ ⦄ ⦃ _ : StrongProductsH J _↠_ ⦄
         → CartesianH _⇨_ _↠_
-      cartesianH = record { F-! = refl↠
-                          ; F-▵ = refl↠
+      cartesianH = record { F-! = refl≈↠
+                          ; F-▵ = refl≈↠
                           ; F-exl = ∘-assoc-elimʳ μ⁻¹∘μ   -- (exl ∘ μ⁻¹) ∘ μ ≈ exl
                           ; F-exr = ∘-assoc-elimʳ μ⁻¹∘μ   -- (exr ∘ μ⁻¹) ∘ μ ≈ exr
                           }


### PR DESCRIPTION
# Intro

With this Agda version there were changes [1] to instance resolution
algorithm, from agda changelog:

[Breaking] The algorithm for resolution of instance arguments has been
simplified. It will now only rely on the type of instances to
determine which candidate it should use, and no longer on their
values.

I've found this thread [2] at zulip, which might be helpful.  It
wasn't for me;)

# Solution

In the end I've removed the opening of the `Equivalent` record module
straight after its definition.  With this version Agda won't be able
to figure out definitions like this:

```agda
F-cong : ∀ {a b} {f g : a ⇨ b} → f ≈ g → Fₘ f ≈ Fₘ g
```

where each `_≈_` belongs to a different instance.  That's why now one
have to manually open appropriate instance.  However if we have only
single `Equivalent` in the context using an `open Equivalent ⦃ … ⦄`
will suffice.

# Additional comments around design

Furthermore I've added explicit implicit ;) arguments to `Equivalent`
fields.  Those are actually important and it is impossible to follow
hint that was stated in the `TODO` comment, that used to said:

> TODO: move a and b arguments from methods to record.

Without those implicit args, definitions like:

```agda
∘≈ : ∀ {f g : a ⇨ b} {h k : b ⇨ c} → h ≈ k → f ≈ g → h ∘ f ≈ k ∘ g
```

wouldn't typecheck as the `Equivalent` would lock it's variables
during instantiation and we could use only those two (`a` & `b` in
this case). `_≈_` would reject morphisms `h` & `k` here as it's
objects would be different.

There is additional `TODO` comment that says:

> TODO: Replace Equivalent by Setoid?

Actually moving variables mentioned above would almost turn Equivalent
into Setoid (minus `Carrier` as a field).  Which isn't really feasible
for the reasons already mentioned.

## How others do it

I've took a peek how agda-categoris does it [3] and they basically put
`Equivalent` into definition of `Category` and call it _Setoid
enriched_.  I've played with that for a bit.  Initially putting `_≈_`
into lawful category.  That didn't work out however because we need
`_≈_` for defining different kinds homomorphisms, where we don't have
lawful classes in scope.  So I've moved it to the raw `Category`, but
the problem with definitions that use multiple equalities still
persists.  I think that restricting the opening of `Category` class
would be too cumbersome.  So I think this split to `Equivalent` works
nice.  I do wonder however if it's worth doing the instance search, if
most of the time one has to manually open appropriate one?

[1] https://github.com/agda/agda/blob/master/doc/release-notes/2.6.4.md#language
[2] https://agda.zulipchat.com/#narrow/stream/238741-general/topic/Issue.20with.20instance.20search.20changes.20in.202.2E6.2E4/near/384560563
[3] https://github.com/agda/agda-categories/blob/master/src/Categories/Category/Core.agda#L21
