### PR TITLE
agda 2.6.4.3 with nixos 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,23 @@
 {
   "nodes": {
-    "agda-stdlib-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1702291622,
-        "narHash": "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=",
-        "owner": "agda",
-        "repo": "agda-stdlib",
-        "rev": "2b8fff10f4033b91a6df4007e4a65cb10047c89c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "agda",
-        "ref": "v2.0",
-        "repo": "agda-stdlib",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701282334,
-        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
+        "lastModified": 1717555607,
+        "narHash": "sha256-WZ1s48OODmRJ3DHC+I/DtM3tDRuRJlNqMvxvAPTD7ec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+        "rev": "0b8e7a1ae5a94da2e1ee3f3030a32020f6254105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "agda-stdlib-src": "agda-stdlib-src",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }
@@ -60,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,15 @@
   description = "Category theory for denotational design";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     utils.url = "github:numtide/flake-utils";
-    agda-stdlib-src = {
-      url = "github:agda/agda-stdlib?ref=v2.0";
-      flake = false;
-    };
-  };
+ };
 
-  outputs = { self, nixpkgs, utils, agda-stdlib-src }:
+  outputs = { self, nixpkgs, utils }:
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        standard-library = pkgs.agdaPackages.standard-library.overrideAttrs (final: prev: {
-          version = "2.0";
-          src = agda-stdlib-src;
-        });
-        agdaWithStandardLibrary = pkgs.agda.withPackages (_: [ standard-library ]);
+        agdaWithStandardLibrary = pkgs.agda.withPackages (p: [ p.standard-library ]);
 
       in {
         checks.whitespace = pkgs.stdenvNoCC.mkDerivation {
@@ -45,7 +37,7 @@
           version = "0.0.1";
           src = ./.;
 
-          buildInputs = [ standard-library ];
+          buildInputs = with pkgs.agdaPackages; [ standard-library ];
 
           everythingFile = "./src/Felix/All.agda";
 


### PR DESCRIPTION
Recently nixos released new version. This one comes with updated Agda and set of libraries, so we no longer have to override, for now ;)

This mean that we'll be fetching standard library from nixos cache instead of building our own from source.